### PR TITLE
fix(app): move router outside of app component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,5 @@
 import React, {useState, useEffect} from 'react';
-import {BrowserRouter as Router, Route} from "react-router-dom";
-
+import {Route, useHistory} from "react-router-dom";
 import LandingPage from './pages/LandingPage1';
 import LogInPage from './pages/LogInPage';
 import SignUpPage from './pages/SignUpPage';
@@ -10,24 +9,24 @@ import RankingPage from './pages/RankingPage';
 import './App.css';
 import { useAuth0 } from '@auth0/auth0-react';
 
-
- const App = () => {
+const App = () => {
+  const history = useHistory()
   const [isLoggedIn, setIsLoggedIn] = useState(false);
 
   const {isAuthenticated, loginWithRedirect, user} = useAuth0();
 
-  useEffect(() => {
-    checkIfAuthenticated();
-  });
-
   // Check if the user is authenenticated every time the page is loaded, if so logs user information and true/false
-  const checkIfAuthenticated = () => {
-    if(isAuthenticated){
+  useEffect(() => {
+    if (isAuthenticated) {
       setIsLoggedIn(true);
+      history.push("/weighIn");
+    } else {
+      setIsLoggedIn(false);
+      history.push('/signUp')
     }
     console.log(isLoggedIn);
     console.log(user);
-  }
+  }, [isAuthenticated, isLoggedIn, user, history]);
 
   // Use Auth0 to log in the user
   const logUserIn = async () => {
@@ -35,24 +34,23 @@ import { useAuth0 } from '@auth0/auth0-react';
   }
 
   return (
-    <Router>
+    <div>
+      <Route
+        exact
+        path="/"
+        render={(props) => <LandingPage logUser={() => logUserIn()} />}
+      />
+      <Route path="/logIn" component={LogInPage} />
+      <Route path="/signUp" component={SignUpPage} />
+      {isLoggedIn && (
         <div>
-          <Route exact path="/" render={props => <LandingPage logUser={() =>logUserIn()} />} />
-          <Route path="/logIn" render={props => <LogInPage />} />
-          <Route path="/signUp" render={props => <SignUpPage />} /> 
-          {isLoggedIn &&
-            <div>
-          <Route path="/weighIn" render={props => <WeighInPage />} />
-          <Route path="/team" render={props => <TeamPage />} /> 
-          <Route path="/ranking" render={props => <RankingPage />} />
-            </div>
-
-          }           
-  
- 
-      </div>
-  </Router>
+          <Route path="/weighIn" component={WeighInPage} />
+          <Route path="/team" component={TeamPage} />
+          <Route path="/ranking" component={RankingPage} />
+        </div>
+      )}
+    </div>
   );
-}
+};
 
 export default App;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter as Router } from 'react-router-dom'
 import './index.css';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import App from './App';
@@ -14,8 +15,10 @@ ReactDOM.render(
     clientId={clientId}
     redirectUri={window.location.origin}
   >
-    <App />
-  </Auth0Provider>    
+    <Router>
+      <App />
+    </Router>
+  </Auth0Provider>
 
 , document.getElementById('root'));
 


### PR DESCRIPTION
Since the `App` component had `BrowserRouter` inside of it, it didn't have access to `history` from the router. Moving it to the same place as the `Auth0Provider` and adding the `useHistory` hook seems to resolve the issue. I also did some cleanup around the `useEffect`. Since there was no dependency array (see https://reactjs.org/docs/hooks-effect.html#tip-optimizing-performance-by-skipping-effects), the effect got into an infinite loop once the page changed.